### PR TITLE
Remove ActionBar shadow on some versions of Android

### DIFF
--- a/App/src/main/res/values/styles.xml
+++ b/App/src/main/res/values/styles.xml
@@ -1,9 +1,10 @@
 <resources>
 
-    <style name="TransparentTheme" parent="@android:style/Theme.Holo.Light">
+    <style name="TransparentTheme" parent="<a style='cursor: pointer;' id='ar0'>@android:style/Theme.Holo.Light</a>">
         <item name="android:windowBackground">@null</item>
         <item name="android:actionBarStyle">@style/ActionBarStyle.Transparent</item>
         <item name="android:windowActionBarOverlay">true</item>
+        <item name="android:windowContentOverlay">@null</item>
     </style>
 
     <style name="ActionBarStyle.Transparent" parent="@android:Widget.ActionBar">

--- a/App/src/main/res/values/styles.xml
+++ b/App/src/main/res/values/styles.xml
@@ -1,6 +1,6 @@
 <resources>
 
-    <style name="TransparentTheme" parent="<a style='cursor: pointer;' id='ar0'>@android:style/Theme.Holo.Light</a>">
+    <style name="TransparentTheme" parent="@android:style/Theme.Holo.Light">
         <item name="android:windowBackground">@null</item>
         <item name="android:actionBarStyle">@style/ActionBarStyle.Transparent</item>
         <item name="android:windowActionBarOverlay">true</item>


### PR DESCRIPTION
I noticed that on my (original) Nexus 7 with Android 4.4.2 the ActionBar - while transparent - had a bottom shadow. This fixed that.
